### PR TITLE
Remove line in header search template

### DIFF
--- a/generators/app/templates/theme/search/forms/search-header.twig
+++ b/generators/app/templates/theme/search/forms/search-header.twig
@@ -4,7 +4,6 @@
     <div class="Arrange Arrange--middle">
         <div class="Arrange-sizeFill">
             {% set form.fields.searchTerm.class = 'SearchForm-input' %}
-            {% set form.fields.searchTerm.id = '' %}
             {% set form.fields.searchTerm.placeholder = 'Search...' %}
             {{ form.fields.searchTerm.tag }}
         </div>


### PR DESCRIPTION
This fixes and issue where the text field class was getting set to `''` (empty string).

Closes #9 