### PR TITLE
Move .SelectInput padding to child select

### DIFF
--- a/generators/app/templates/src/css/components/form/selectmenu.css
+++ b/generators/app/templates/src/css/components/form/selectmenu.css
@@ -30,7 +30,6 @@
     color: var(--SelectInput-color);
     display: inline-block;
     outline: none;
-    padding: var(--SelectInput-padding);
     position: relative;
 }
 
@@ -65,7 +64,7 @@
     display: block;
     margin: 0; /* 1 */
     outline: 0; /* 1 */
-    padding: 0 2.3rem 0 .35rem;
+    padding: var(--SelectInput-padding);
     position: relative; /* 2 */
     width: 100%;
 }


### PR DESCRIPTION
Move the padding from .SelectInput to the child select to improve the appearance on Windows browsers.